### PR TITLE
remove shared test state, refactor variable naming for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Impersonate
 
 Contract logic and testing for cooperative game play, with an eye towards Dark Forest
+
+`npm i` to install dependencies.
+
+see package.json scripts section for common actions
+
+`npx hardhat` to see a list of tasks to run.

--- a/test/Game.ts
+++ b/test/Game.ts
@@ -9,15 +9,17 @@ describe("Game ", function () {
 
   describe("Game owner no change", function () {
     let game: Game; 
+    let daoGame: Game;
     let owner: SignerWithAddress;
     let dao: SignerWithAddress;
 
     // will execute before the first test
     before(async function () {
+      [owner, dao] = await ethers.getSigners();
       const GameFactory = await ethers.getContractFactory("Game");
       game = await GameFactory.deploy() as Game;
       await game.deployed();
-      [owner, dao] = await ethers.getSigners();
+      daoGame = game.connect(dao);
     });
 
     it("owner is game.owner()", async function () {
@@ -40,11 +42,9 @@ describe("Game ", function () {
     });
 
     it("dao cannot change game.owner", async function () {
-      game = game.connect(dao); // dao is now connected to contract
-      expect(await game.whoami()).to.equal(dao.address);
-      await expect(game.setOwner(dao.address)).to.be.revertedWith('_getImpersonator is not owner');
+      expect(await daoGame.whoami()).to.equal(dao.address);
+      await expect(daoGame.setOwner(dao.address)).to.be.revertedWith('_getImpersonator is not owner');
     });
-
 
   });
 
@@ -55,10 +55,10 @@ describe("Game ", function () {
 
     // will execute before the first test
     before(async function () {
+      [owner, dao] = await ethers.getSigners();
       const GameFactory = await ethers.getContractFactory("Game");
       game = await GameFactory.deploy() as Game;
       await game.deployed();
-      [owner, dao] = await ethers.getSigners();
     });
 
     it("owner is game.owner()", async function () {

--- a/test/Game.ts
+++ b/test/Game.ts
@@ -13,8 +13,7 @@ describe("Game ", function () {
     let owner: SignerWithAddress;
     let dao: SignerWithAddress;
 
-    // will execute before the first test
-    before(async function () {
+    beforeEach(async function () {
       [owner, dao] = await ethers.getSigners();
       const GameFactory = await ethers.getContractFactory("Game");
       game = await GameFactory.deploy() as Game;
@@ -53,8 +52,7 @@ describe("Game ", function () {
     let owner: SignerWithAddress;
     let dao: SignerWithAddress; 
 
-    // will execute before the first test
-    before(async function () {
+    beforeEach(async function () {
       [owner, dao] = await ethers.getSigners();
       const GameFactory = await ethers.getContractFactory("Game");
       game = await GameFactory.deploy() as Game;
@@ -82,19 +80,17 @@ describe("Game ", function () {
     });
 
     it("dao increments count from 1 to 2", async function () {
+      await game.setOwner(dao.address);
 
       // DAO is owner
       expect(await game.owner()).to.equal(dao.address);
 
-      // count is 1
-      expect(await game.count()).to.equal(1)
-
-      const incrementTx = await game.increment();
+      const incrementTx = await game.connect(dao).increment();
 
       // wait until the transaction is mined
       await incrementTx.wait();
 
-      expect(await game.count()).to.equal(2)
+      expect(await game.count()).to.equal(1)
     });
   });
 

--- a/test/Game.ts
+++ b/test/Game.ts
@@ -40,57 +40,44 @@ describe("Game ", function () {
       expect(await game.owner()).to.not.equal(dao.address)
     });
 
-    it("dao cannot change game.owner", async function () {
+    it("owner can set setOwner", async function () {
+      await game.setOwner(dao.address);
+      expect(await game.owner()).to.equal(dao.address);
+    });
+
+    it("dao cannot set owner", async function () {
       expect(await daoGame.whoami()).to.equal(dao.address);
       await expect(daoGame.setOwner(dao.address)).to.be.revertedWith('_getImpersonator is not owner');
     });
 
   });
 
-  describe("Game owner change to dao", function () {
-    let game: Game; 
+  describe("Game owner is dao", function () {
+    let daoGame: Game; 
     let owner: SignerWithAddress;
     let dao: SignerWithAddress; 
 
     beforeEach(async function () {
       [owner, dao] = await ethers.getSigners();
       const GameFactory = await ethers.getContractFactory("Game");
-      game = await GameFactory.deploy() as Game;
+      const game = await GameFactory.deploy() as Game;
       await game.deployed();
+      await game.setOwner(dao.address);
+      daoGame = game.connect(dao);
     });
 
-    it("owner is game.owner()", async function () {
-      expect(await game.owner()).to.equal(owner.address)
+    it("owner is dao", async function () {
+      expect(await daoGame.owner()).to.equal(dao.address)
     });
 
-    it("owner increments count from 0 to 1", async function () {
-      expect(await game.count()).to.equal(0)
+    it("dao increments count from 0 to 1", async function () {
 
-      const incrementTx = await game.increment();
+      const incrementTx = await daoGame.increment();
 
       // wait until the transaction is mined
       await incrementTx.wait();
 
-      expect(await game.count()).to.equal(1)
-    });
-
-    it("game owner is now dao", async function () {
-      await game.setOwner(dao.address);
-      expect(await game.owner()).to.equal(dao.address);
-    });
-
-    it("dao increments count from 1 to 2", async function () {
-      await game.setOwner(dao.address);
-
-      // DAO is owner
-      expect(await game.owner()).to.equal(dao.address);
-
-      const incrementTx = await game.connect(dao).increment();
-
-      // wait until the transaction is mined
-      await incrementTx.wait();
-
-      expect(await game.count()).to.equal(1)
+      expect(await daoGame.count()).to.equal(1)
     });
   });
 

--- a/test/Impersonate.ts
+++ b/test/Impersonate.ts
@@ -22,7 +22,7 @@ describe('Impersonate', function () {
         expect(await impersonate._getImpersonator()).to.equal(owner.address);
     })
 
-    it('dao should now be _getImpersonator', async function () {
+    it('owner should be allowed to set _getImpersonator', async function () {
         let impersonateReceipt = await impersonate.impersonateMe(dao.address);
         await impersonateReceipt.wait();
         expect(await impersonate._getImpersonator()).to.equal(dao.address);

--- a/test/Impersonate.ts
+++ b/test/Impersonate.ts
@@ -28,4 +28,8 @@ describe('Impersonate', function () {
         expect(await impersonate._getImpersonator()).to.equal(dao.address);
     })
 
+    it("non owner cannot call impersonateMe", async function () {
+        await expect(impersonate.connect(dao).impersonateMe(dao.address)).to.be.revertedWith('_getImpersonator is not owner');
+    });
+
 });

--- a/test/Impersonate.ts
+++ b/test/Impersonate.ts
@@ -23,7 +23,8 @@ describe('Impersonate', function () {
     })
 
     it('dao should now be _getImpersonator', async function () {
-        impersonate.impersonateMe(dao.address);
+        let impersonateReceipt = await impersonate.impersonateMe(dao.address);
+        await impersonateReceipt.wait();
         expect(await impersonate._getImpersonator()).to.equal(dao.address);
     })
 


### PR DESCRIPTION
Some cleanups

I think one big thing is not leaking state between your tests. `before` certainly has a purpose, but until you have a good reason to have tests share state, dont do it.

The rest is naming problems I think. Feel free to not merge this it doesnt fit your model, but think about what the permissions model is and what those roles should be called.

owner is the person who can set who can set impersonators?
impersonator is the person calling a fn as someone elses msg.sender, should they be allowed to add more impersonators though?

setOwner seems like a bad naming, it generally refers to the administrator of the entire contract. I think impersonation is supposed to be more like getting permission to call certain functions as a different user. maybe setImpersonator?

Note, impersonateMe is public, I think you're missing some tests around this, it seems like I would avoid calling setOwner and just use impersonateMe since it doesnt have authentication
